### PR TITLE
Fix quoting in run-playbook script

### DIFF
--- a/ansible/run-playbook.sh
+++ b/ansible/run-playbook.sh
@@ -18,6 +18,6 @@ fi
 
 # Execute the ansible-playbook command
 ansible-playbook -i "$INVENTORY_FILE" "$PLAYBOOK_FILE" -K \
--e "inventory_file=$INVENTORY_FILE" \
--e "unique_hash=$(cat $INVENTORY_FILE | sha256sum | cut -c1-5) \
--e env=$ENVIRONMENT"
+  -e "inventory_file=$INVENTORY_FILE" \
+  -e "unique_hash=$(sha256sum < "$INVENTORY_FILE" | cut -c1-5)" \
+  -e "env=$ENVIRONMENT"


### PR DESCRIPTION
## Summary
- fix quoting in run-playbook script so Ansible variables are passed correctly

## Testing
- `shellcheck ansible/run-playbook.sh`


------
https://chatgpt.com/codex/tasks/task_e_685698496020832799950817d2b6000f