### PR TITLE
Install Argo CD via Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homelab Base
 
-This repository is designed to facilitate the setup and management of a Kubernetes-based homelab environment. It leverages a combination of Ansible, Helm, and Terraform to deploy and configure various applications and services on a Kubernetes cluster.
+This repository is designed to facilitate the setup and management of a Kubernetes-based homelab environment. It primarily leverages Ansible and Helm to deploy and configure services on a Kubernetes cluster.  Terraform is available for infrastructure provisioning but is no longer used for installing in‑cluster applications like Argo CD.
 
 ## Project Structure
 
@@ -16,7 +16,7 @@ The project is organized into several key directories, each serving a specific p
 
 - **downloaded-charts**: Contains downloaded Helm charts for various applications.
 
-- **terraform**: Contains Terraform configuration files and scripts for managing infrastructure resources. Key files include `argocd-values.yaml`, `base-application.yaml`, `main.tf`, `providers.tf`, and `variables.tf`.
+- **terraform**: Optional Terraform configuration used for infrastructure provisioning. Key files include `main.tf`, `providers.tf`, and `variables.tf`.
 
 ## Getting Started
 
@@ -24,13 +24,13 @@ The project is organized into several key directories, each serving a specific p
 
 - **Helm**: Ensure Helm is installed to manage Kubernetes applications.
 - **Ansible**: Required for executing playbooks to configure the K3s cluster.
-- **Terraform**: Used for infrastructure management and provisioning.
+- **Terraform**: Optional, used only for infrastructure provisioning outside the cluster.
 
 ### Installation
 
 1. **Install K3s**: Use the Ansible playbooks in the `ansible` directory to set up the K3s server and agent.
 
-2. **Install Argo CD**: The first thing to be installed on the cluster is Argo CD, along with the root application, and some secrets tooling.
+2. **Install Argo CD**: Use the provided Ansible role to install Argo CD and bootstrap the root application and required secrets.
 
 3. **Install Core Applications**: Argo CD pulls the contents of the base-applications and CRD resources into the cluster. These are kind of like a "platform" that just supply prerequisites to get things running nicely, like certificates, DNS, redundant storage, etc.
 

--- a/ansible/group_vars_example/all.yml
+++ b/ansible/group_vars_example/all.yml
@@ -1,0 +1,5 @@
+project_dir: "/home/benjdaun/homelab_base"
+github_username: "YOUR_GITHUB_USERNAME"
+github_token: "YOUR_GITHUB_TOKEN"
+bitwarden_username: "YOUR_BITWARDEN_USERNAME"
+bitwarden_password: "YOUR_BITWARDEN_PASSWORD"

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -49,3 +49,10 @@
       ansible.builtin.systemd:
         name: iscsid
         state: started
+
+- hosts: localhost
+  become: true
+  become_user: benjdaun
+  roles:
+    - argocd
+

--- a/ansible/roles/argocd/tasks/main.yml
+++ b/ansible/roles/argocd/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- name: Add Argo CD Helm repository
+  shell: |
+    helm repo add argo https://argoproj.github.io/argo-helm
+    helm repo update
+  environment:
+    KUBECONFIG: "{{ project_dir }}/kubeconfigs/{{ env }}/{{ unique_hash }}-kubeconfig"
+  args:
+    creates: "{{ project_dir }}/kubeconfigs/{{ env }}/.argo_repo_added"
+
+- name: Mark repo added
+  file:
+    path: "{{ project_dir }}/kubeconfigs/{{ env }}/.argo_repo_added"
+    state: touch
+
+- name: Install or upgrade Argo CD
+  shell: |
+    helm upgrade --install argocd argo/argo-cd \
+      --namespace argocd \
+      --create-namespace \
+      --version 7.6.5 \
+      -f {{ project_dir }}/terraform/argocd-values.yaml \
+      -f {{ project_dir }}/terraform/argocd-values-{{ env }}.yaml
+  environment:
+    KUBECONFIG: "{{ project_dir }}/kubeconfigs/{{ env }}/{{ unique_hash }}-kubeconfig"
+
+- name: Ensure secrets-management namespace exists
+  shell: |
+    kubectl get namespace secrets-management || kubectl create namespace secrets-management
+  environment:
+    KUBECONFIG: "{{ project_dir }}/kubeconfigs/{{ env }}/{{ unique_hash }}-kubeconfig"
+
+- name: Create Bitwarden CLI secret
+  shell: |
+    kubectl -n secrets-management apply -f - <<'EOM'
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: bitwarden-cli
+    stringData:
+      BW_HOST: "https://vault.bitwarden.com/"
+      BW_USERNAME: "{{ bitwarden_username }}"
+      BW_PASSWORD: "{{ bitwarden_password }}"
+    EOM
+  environment:
+    KUBECONFIG: "{{ project_dir }}/kubeconfigs/{{ env }}/{{ unique_hash }}-kubeconfig"
+
+- name: Create GitHub repository credentials
+  shell: |
+    kubectl -n argocd apply -f - <<'EOM'
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: github-homelab-cred
+      labels:
+        argocd.argoproj.io/secret-type: repository
+    stringData:
+      username: "{{ github_username }}"
+      password: "{{ github_token }}"
+      project: "default"
+      type: "git"
+      url: "https://github.com/benjdaun/homelab_base"
+    EOM
+  environment:
+    KUBECONFIG: "{{ project_dir }}/kubeconfigs/{{ env }}/{{ unique_hash }}-kubeconfig"
+
+- name: Deploy base Argo CD application
+  shell: |
+    kubectl apply -f {{ project_dir }}/terraform/base-application.yaml
+  environment:
+    KUBECONFIG: "{{ project_dir }}/kubeconfigs/{{ env }}/{{ unique_hash }}-kubeconfig"


### PR DESCRIPTION
## Summary
- move Argo CD deployment into a new Ansible role
- include example group vars file with required secrets
- hook the new role into the main playbook
- document new approach in README

## Testing
- `ansible-playbook --syntax-check ansible/playbook.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0642ee88327b8aee81804269a92